### PR TITLE
Remove booking cards from weekends and holidays

### DIFF
--- a/TarsOffice/Extensions/DateTimeExtensions.cs
+++ b/TarsOffice/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,15 @@
+﻿using DateTimeExtensions;
+using DateTimeExtensions.WorkingDays;
+using System;
+
+namespace TarsOffice.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        private static readonly IWorkingDayCultureInfo cultureInfo = new WorkingDayCultureInfo("pt-PT");
+
+        public static DateTime AddWorkingDays(this DateTime date, int days) => date.AddWorkingDays(days, cultureInfo);
+
+        public static bool IsWorkingDay(this DateTime date) => date.IsWorkingDay(cultureInfo);
+    }
+}

--- a/TarsOffice/Pages/Bookings/Create.cshtml.cs
+++ b/TarsOffice/Pages/Bookings/Create.cshtml.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using TarsOffice.Data;
 using TarsOffice.Extensions;
@@ -14,9 +11,9 @@ namespace TarsOffice.Pages.Bookings
 {
     public class CreateModel : PageModel
     {
-        private readonly TarsOffice.Data.ApplicationDbContext _context;
+        private readonly ApplicationDbContext _context;
 
-        public CreateModel(TarsOffice.Data.ApplicationDbContext context)
+        public CreateModel(ApplicationDbContext context)
         {
             _context = context;
         }
@@ -30,7 +27,7 @@ namespace TarsOffice.Pages.Bookings
             }
             else
             {
-                Booking.Date = DateTime.Today.AddDays(1);
+                Booking.Date = DateTime.Today.AddWorkingDays(1);
             }
 
             return Page();
@@ -47,13 +44,16 @@ namespace TarsOffice.Pages.Bookings
             {
                 User = user
             };
-            if(await TryUpdateModelAsync<Booking>(newBooking, "booking", s => s.Date, s =>s.Status))
+            if(await TryUpdateModelAsync(newBooking, "booking", s => s.Date, s =>s.Status))
             {
                 //truncate date
                 newBooking.Date = newBooking.Date.Date;
-                _context.Bookings.Add(newBooking);
-                await _context.SaveChangesAsync();
-                return RedirectToPage("../Index");
+                if (newBooking.Date.IsWorkingDay())
+                {
+                    _context.Bookings.Add(newBooking);
+                    await _context.SaveChangesAsync();
+                    return RedirectToPage("../Index");
+                }
             }
 
             return Page();

--- a/TarsOffice/Pages/Index.cshtml.cs
+++ b/TarsOffice/Pages/Index.cshtml.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using TarsOffice.Data;
-using TarsOffice.DayFeatures;
 using TarsOffice.DayFeatures.Abstractions;
 using TarsOffice.Extensions;
 using TarsOffice.Viewmodel;
@@ -48,7 +47,7 @@ namespace TarsOffice.Pages
                 .Select(x => x.Key);
 
             var startDate = DateTime.Today;
-            var lastDate = startDate.AddDays(11);
+            var lastDate = startDate.AddWorkingDays(11);
             var nextTeamBookings = await context.Bookings
                 .Include(booking => booking.User)
                 .Where(booking => booking.Date <= lastDate && booking.Date >= startDate)
@@ -57,7 +56,7 @@ namespace TarsOffice.Pages
                 .ToListAsync();
 
             TeamBookings = new List<TeamDayBookings>();
-            for (var date = startDate; date <= lastDate; date = date.AddDays(1))
+            for (var date = startDate; date <= lastDate; date = date.AddWorkingDays(1))
             {
                 var bookings = nextTeamBookings.Where(b => b.Date == date);
                 TeamBookings.Add(new TeamDayBookings

--- a/TarsOffice/TarsOffice.csproj
+++ b/TarsOffice/TarsOffice.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DateTimeExtensions" Version="5.5.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.20" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.20" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.20" />


### PR DESCRIPTION
- [x] Only display bookings for Workings days. Exclude weekends and Holidays.
- [x] Don't allow bookings on those days.

I created a DateTime extension that uses the DateTimeExtensions project, only because I wanted a way to set the culture once and not have to initialize it in the two pages it is used. But if you know a better way to set this, I'm happy to change it.

Closes #3 